### PR TITLE
Added missing type in function definition in example init.

### DIFF
--- a/docs/core/component/lifecycle/init.md
+++ b/docs/core/component/lifecycle/init.md
@@ -36,7 +36,7 @@ class basicSimLifeCycle : public SST::Component {
 	~basicSimLifeCycle();
 
     //highlight-next-line
-    virtual void init(unsigned phase) override;
+    virtual void init(unsigned int phase) override;
 
 	/** Other public functions here */
 


### PR DESCRIPTION
Fixed issue with missing type in the example init function. 