### PR TITLE
update `sst --help` snippet

### DIFF
--- a/docs/guides/runningSST.md
+++ b/docs/guides/runningSST.md
@@ -36,47 +36,90 @@ Informational Options
 -V --version                       ---- Print SST Release Version
 
 Basic Options (most commonly used)
--v --verbose=[level]               -S-- Verbosity level to determine what information about core runtime is printed.  If no argument is specified, it will simply increment the verbosity level.
+-v --verbose=[level]               -S-- Verbosity level to determine what information about core runtime is printed.  If no
+                                        argument is specified, it will simply increment the verbosity level.
 -n --num-threads=NUM               -S-- Number of parallel threads to use per rank
-   --sdl-file=FILE                 ---- Specify SST Configuration file.  Note: this is most often done by just specifying the file without an option. The SDL file can be the manifest file from a checkpoint (*.sstcpt).
-   --model-options=STR             ---X Provide options to the python configuration script.  Additionally, any arguments provided after a final '-- ' will be appended to the model options (or used as the model options if --model-options was not specified).
-   --print-timing-info=[LEVEL]     -SR- Print SST timing information.  Can supply an optional level to control the granularity of timing information. Level = 0 turns all timing info off, level = 1 will print total runtime, as well as other performance
-                                        data. Level >= 2 will print increasing granularity of performance data. If specified with no level, then the level will be set to 2.
+   --sdl-file=FILE                 ---- Specify SST Configuration file.  Note: this is most often done by just specifying
+                                        the file without an option. The SDL file can be the manifest file from a checkpoint
+                                        (*.sstcpt).
+   --model-options=STR             ---X Provide options to the python configuration script.  Additionally, any arguments
+                                        provided after a final '-- ' will be appended to the model options (or used as the
+                                        model options if --model-options was not specified).
+   --print-timing-info=[LEVEL]     -SR- Print SST timing information.  Can supply an optional level to control the
+                                        granularity of timing information. Level = 0 turns all timing info off, level = 1
+                                        will print total runtime, as well as other performance data. Level >= 2 will print
+                                        increasing granularity of performance data. If specified with no level, then the
+                                        level will be set to 2.
    --timing-info-json=FILE         -SR- Write SST timing information in JSON format
    --stop-at=TIME                  -SR- Set time at which simulation will end execution
-   --exit-after=TIME               -S-- Set the maximum wall time after which simulation will end execution.  Time is specified in hours, minutes and seconds, with the following formats supported: H:M:S, M:S, S, Hh, Mm, Ss (capital letters are the
-                                        appropriate numbers for that value, lower case letters represent the units and are required for those formats).
+   --exit-after=TIME               -S-- Set the maximum wall time after which simulation will end execution.  Time is
+                                        specified in hours, minutes and seconds, with the following formats supported:
+                                        H:M:S, M:S, S, Hh, Mm, Ss (capital letters are the appropriate numbers for that
+                                        value, lower case letters represent the units and are required for those formats).
    --partitioner=PARTITIONER       -SR- Select the partitioner to be used. <lib.partitionerName>
-   --heartbeat-period=PERIOD       -SR- Set time for heartbeats to be published (these are approximate timings measured in simulation time, published by the core, to update on progress)
-   --heartbeat-wall-period=PERIOD  -SR- Set approximate frequency for heartbeats (SST-Core progress updates) to be published in terms of wall (real) time. PERIOD can be specified in hours, minutes, and seconds with the following formats supported: H:M:S,
-                                        M:S, S, Hh, Mm, Ss (capital letters are the appropriate numbers for that value, lower case letters represent the units and are required for those formats.).
-   --heartbeat-sim-period=PERIOD   -SR- Set approximate frequency for heartbeats (SST-Core progress updates) to be published in terms of simulated time. PERIOD must include time units (s or Hz) and SI prefixes are accepted.
+   --heartbeat-period=PERIOD       -SR- Set time for heartbeats to be published (these are approximate timings measured in
+                                        simulation time, published by the core, to update on progress)
+   --heartbeat-wall-period=PERIOD  -SR- Set approximate frequency for heartbeats (SST-Core progress updates) to be
+                                        published in terms of wall (real) time. PERIOD can be specified in hours, minutes,
+                                        and seconds with the following formats supported: H:M:S, M:S, S, Hh, Mm, Ss
+                                        (capital letters are the appropriate numbers for that value, lower case letters
+                                        represent the units and are required for those formats.).
+   --heartbeat-sim-period=PERIOD   -SR- Set approximate frequency for heartbeats (SST-Core progress updates) to be
+                                        published in terms of simulated time. PERIOD must include time units (s or Hz) and
+                                        SI prefixes are accepted.
    --output-directory=DIR          -S-- Directory into which all SST output files should reside
    --output-prefix-core=STR        -SRX set the SST::Output prefix for the core
 
 Configuration Output Options (generates a file that can be used as input for reproducing a run)
    --output-config=FILE            -S-X File to write SST configuration (in Python format)
    --output-json=FILE              -S-X File to write SST configuration graph (in JSON format)
-                                        specified, the same file will be passed to all MPI ranks.  If MULTI is specified, each MPI rank is required to have it's own file to load. Note, not all input formats support both types of file loading.
+   --parallel-output=[BOOL]        -S-X Enable parallel output of configuration information.  This option is ignored for
+                                        single rank jobs.  Must also specify an output type (--output-config and/or
+                                        --output-json).  Note: this will also cause partition info to be output if set to
+                                        true.
+
+Graph Output Options (for outputting graph information for visualization or inspection)
+   --output-dot=FILE               -S-X File to write SST configuration graph (in GraphViz format)
+   --dot-verbosity=INT             -S-X Amount of detail to include in the dot graph output
+   --output-partition=[FILE]       -S-- File to write SST component partitioning information.  When used without an
+                                        argument and in conjunction with --output-json or --output-config options, will
+                                        cause partition information to be added to graph output.
+
+Advanced Options
+   --timebase=TIMEBASE             HSRX Set the base time step of the simulation (default: 1ps)
+   --parallel-load=[MODE]          ---X Enable parallel loading of configuration. This option is ignored for single rank
+                                        jobs.  Optional mode parameters are NONE, SINGLE and MULTI (default).  If NONE is
+                                        specified, parallel-load is turned off. If SINGLE is specified, the same file will
+                                        be passed to all MPI ranks.  If MULTI is specified, each MPI rank is required to
+                                        have it's own file to load. Note, not all input formats support both types of file
+                                        loading.
    --timeVortex=MODULE             -SR- Select TimeVortex implementation <lib.timevortex>
    --interthread-links=[BOOL]      -S-- [EXPERIMENTAL] Set whether or not interthread links should be used
    --cache-align-mempools=[BOOL]   -SRX [EXPERIMENTAL] Set whether mempool allocations are cache aligned
    --debug-file=FILE               -S-X File where debug output will go
    --lib-path=LIBPATH              --R- Component library path (overwrites default)
    --add-lib-path=LIBPATH          --R- Component library path (appends to main path)
-   --enable-python-coverage        H--X [EXPERIMENTAL] Causes the base Python interpreter to activate the coverage.Coverage object. This option can also be turned on by setting the environment variable SST_CONFIG_PYTHON_COVERAGE to true.
+   --enable-python-coverage        H--X [EXPERIMENTAL] Causes the base Python interpreter to activate the coverage.Coverage
+                                        object. This option can also be turned on by setting the environment variable
+                                        SST_CONFIG_PYTHON_COVERAGE to true.
 
 Advanced Options - Profiling (API Not Yet Final)
-   --enable-profiling=POINTS       HS-- Enables default profiling for the specified points.  Argument is a semicolon separated list specifying the points to enable.
+   --enable-profiling=POINTS       HS-- Enables default profiling for the specified points.  Argument is a semicolon
+                                        separated list specifying the points to enable.
    --profiling-output=FILE         -S-- Set output location for profiling data [stdout (default) or a filename]
 
 Advanced Options - Debug
    --run-mode=MODE                 -S-X Set run mode [ init | run | both (default)]
-   --interactive-console=ACTION    -S-- [EXPERIMENTAL] Set console to use for interactive mode (overrides default console: sst.interactive.simpledebug). NOTE: This currently only works for serial jobs and will be ignored for parallel runs.
-   --interactive-start=[TIME]      -S-- [EXPERIMENTAL] Drop into interactive mode at specified simulated time.  If no time is specified, or the time is 0, then it will drop into interactive mode before any events are processed in the main run loop. NOTE:
-                                        This currently only works for serial jobs and this option will be ignored for parallel runs.
+   --interactive-console=ACTION    -S-- [EXPERIMENTAL] Set console to use for interactive mode (overrides default console:
+                                        sst.interactive.simpledebug). NOTE: This currently only works for serial jobs and
+                                        will be ignored for parallel runs.
+   --interactive-start=[TIME]      -S-- [EXPERIMENTAL] Drop into interactive mode at specified simulated time.  If no time
+                                        is specified, or the time is 0, then it will drop into interactive mode before any
+                                        events are processed in the main run loop. NOTE: This currently only works for
+                                        serial jobs and this option will be ignored for parallel runs.
    --replay-file=FILE              ---- Specify file for replaying an interactive debug console session.
-   --output-undeleted-events=FILE  -S-- file to write information about all undeleted events at the end of simulation (STDOUT and STDERR can be used to output to console)
+   --output-undeleted-events=FILE  -S-- file to write information about all undeleted events at the end of simulation
+                                        (STDOUT and STDERR can be used to output to console)
    --force-rank-seq-startup        ---X Force startup phases of simulation to execute one rank at a time for debug purposes
 
 Advanced Options - Environment Setup/Reporting
@@ -85,18 +128,30 @@ Advanced Options - Environment Setup/Reporting
    --disable-signal-handlers       ---- Disable signal handlers
    --sigusr1=MODULE                HSR- Select handler for SIGUSR1 signal. See extended help for detail.
    --sigusr2=MODULE                HSR- Select handler for SIGUSR2 signal. See extended help for detail.
-   --sigalrm=MODULE                HSR- Select handler for SIGALRM signals.  Argument is a semicolon separated list specifying the handlers to register along with a time interval for each. See extended help for detail.
+   --sigalrm=MODULE                HSR- Select handler for SIGALRM signals.  Argument is a semicolon separated list
+                                        specifying the handlers to register along with a time interval for each. See
+                                        extended help for detail.
 
 Advanced Options - Checkpointing (EXPERIMENTAL)
-   --checkpoint-enable             ---- Allows checkpoints to be triggered from the interactive debug console. This option is not needed if checkpoint-wall-period, checkpoint-period, or checkpoint-sim-period are used.
-   --checkpoint-wall-period=PERIOD -S-- Set approximate frequency for checkpoints to be generated in terms of wall (real) time. PERIOD can be specified in hours, minutes, and seconds with the following formats supported: H:M:S, M:S, S, Hh, Mm, Ss (capital
-                                        letters are the appropriate numbers for that value, lower case letters represent the units and are required for those formats.).
-   --checkpoint-period=PERIOD      -S-- Set approximate frequency for checkpoints to be generated in terms of simulated time. PERIOD must include time units (s or Hz) and SI prefixes are accepted. This flag will eventually be removed in favor of
-                                        --checkpoint-sim-period
-   --checkpoint-sim-period=PERIOD  -S-- Set approximate frequency for checkpoints to be generated in terms of simulated time. PERIOD must include time units (s or Hz) and SI prefixes are accepted.
-   --load-checkpoint               -S-- [UNUSED] This options is no longer needed.  SST will automatically detect if a checkpoint file is specified as the SDL file by detecting the .sstcpt extension.
-   --checkpoint-prefix=PREFIX      HS-- Set prefix for checkpoint filenames. The checkpoint prefix defaults to checkpoint if this option is not set and checkpointing is enabled.
-   --checkpoint-name-format=FORMAT HS-- Set the format for checkpoint filenames. See extended help for format options.  Default is "%p_%n_%t/%p_%n_%t"
+   --checkpoint-enable             ---- Allows checkpoints to be triggered from the interactive debug console. This option
+                                        is not needed if checkpoint-wall-period, checkpoint-period, or
+                                        checkpoint-sim-period are used.
+   --checkpoint-wall-period=PERIOD -S-- Set approximate frequency for checkpoints to be generated in terms of wall (real)
+                                        time. PERIOD can be specified in hours, minutes, and seconds with the following
+                                        formats supported: H:M:S, M:S, S, Hh, Mm, Ss (capital letters are the appropriate
+                                        numbers for that value, lower case letters represent the units and are required for
+                                        those formats.).
+   --checkpoint-period=PERIOD      -S-- Set approximate frequency for checkpoints to be generated in terms of simulated
+                                        time. PERIOD must include time units (s or Hz) and SI prefixes are accepted. This
+                                        flag will eventually be removed in favor of --checkpoint-sim-period
+   --checkpoint-sim-period=PERIOD  -S-- Set approximate frequency for checkpoints to be generated in terms of simulated
+                                        time. PERIOD must include time units (s or Hz) and SI prefixes are accepted.
+   --load-checkpoint               -S-- [UNUSED] This options is no longer needed.  SST will automatically detect if a
+                                        checkpoint file is specified as the SDL file by detecting the .sstcpt extension.
+   --checkpoint-prefix=PREFIX      HS-- Set prefix for checkpoint filenames. The checkpoint prefix defaults to checkpoint
+                                        if this option is not set and checkpointing is enabled.
+   --checkpoint-name-format=FORMAT HS-- Set the format for checkpoint filenames. See extended help for format options. 
+                                        Default is "%p_%n_%t/%p_%n_%t"
 ```
 
 ## Simulation Examples


### PR DESCRIPTION
Updates the snippet of `sst --help` found at https://sst-simulator.org/sst-docs/docs/guides/runningSST#sst-options. Before these changes, the snippet did not contain configuration output options such as `--parallel-output` nor graph output options. 