### PR TITLE
clarifies `default_value` intent

### DIFF
--- a/docs/core/eli/document/sst_eli_document_params.md
+++ b/docs/core/eli/document/sst_eli_document_params.md
@@ -16,7 +16,7 @@ SST_ELI_DOCUMENT_PARAMS	(
 
 *Availability:* Component, SubComponent, Module, ProfilePoint
 
-Use this macro to register the parameters that an SST object accepts. The macro accepts a list of triples where each triple contains the name of the parameter, a description of the parameter, and, optionally a default value. All fields are provided as strings.
+Use this macro to register the parameters that an SST object accepts. The macro accepts a list of triples where each triple contains the name of the parameter, a description of the parameter, and, optionally a default value to communicate to the user what will happen if they don't provide a value. All fields are provided as strings.
 
 :::info Important
 This macro must reside in a `public` section of the object's header file.
@@ -26,7 +26,7 @@ This macro must reside in a `public` section of the object's header file.
 
 * **param_nameX** (string) The name of the parameter.
 * **description** (string) Description of the parameter. This value is displayed when sst-info is run at the command line.
-* **default_value** (string) Optional, a default value that the object assigns the parameter if the parameter is not given in the SST configuration file. If a parameter is required, make this NULL or omit it.
+* **default_value** (string) Optional, a default value to communicate to the user what will happen if they do not pass a value for the component. If a parameter is required, make this NULL or omit it. **Note:** this is informational only; defaults must be set in code by the component author.
 
 :::info
 `param_nameX` must follow SST's [element naming conventions](../../../guides/dev/naming).


### PR DESCRIPTION
There was a misconception on the team that the `default_value` parameter in the `SST_ELI_DOCUMENT_PARAMS` macro was actually supposed to assign a default value. This updates the wording to make it more explicit that it is there to just communicate to the component user what the default value will be if they don't provide a value. The change is for this page: https://sst-simulator.org/sst-docs/docs/core/eli/document/sst_eli_document_params. 

Before:
<img width="995" height="526" alt="image" src="https://github.com/user-attachments/assets/17800747-77d4-4dfe-8e0b-7c2c72d78b9c" />

After:
<img width="985" height="569" alt="image" src="https://github.com/user-attachments/assets/32219906-2de3-46c9-ad15-2b3d2c38afb4" />
